### PR TITLE
utils: Normalize slashes in multilevel workspace members on Windows

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -20,6 +20,7 @@ pub fn list_rust_files(dir: &Path) -> Result<Vec<String>, Error> {
 
 fn member(manifest: &Path, members: &[String], package: &str) -> Result<Option<PathBuf>, Error> {
     for member in members {
+        let member = member.split('/').collect::<PathBuf>();
         let manifest_path = manifest.parent().unwrap().join(member).join("Cargo.toml");
         let manifest = Manifest::parse_from_toml(&manifest_path)?;
         if let Some(p) = manifest.package.as_ref() {


### PR DESCRIPTION
Multilevel cargo workspace members are always written with a forward
slash, for example:

    [workspace]
    members = [
        "apps/android-app",
    ]

On Windows forward slashes are not accepted at all, not even
fs::canonicalize() is able to normalize them. Calling that function or
trying to read a file from a path containing this string results in the
following error:

    Error: The filename, directory name, or volume label syntax is
    incorrect. (os error 123)

Splitting the member name on a forward slash and constructing a new
PathBuf from the parts seems the easiest to get a properly normalized
path with the right separator for the platform.

---

Perhaps this line should be scoped by `#[cfg(windows)]` but I rather keep it generic. I initally expected `PathBuf` to have a `.extend()` method accepting an iterator so that the result from `.split()` can be shoved right in there, but alas. And folding over the result to recursively `.join()` it to the path seems too verbose, so `.collect` seems the simplest solution.