### PR TITLE
Fix build error when wildcard used in workspace.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,72 +4,77 @@
 name = "cargo-subcommand"
 version = "0.4.5"
 dependencies = [
- "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glob",
+ "serde",
+ "toml",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "proc-macro2"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1502d12e458c49a4c9cbff560d0fe0060c252bc29799ed94ca2ed4bb665a0101"
 dependencies = [
- "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid",
 ]
 
 [[package]]
 name = "quote"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a21852a652ad6f610c9510194f398ff6f8692e334fd1145fed931f7fbe44ea"
 dependencies = [
- "proc-macro2 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2",
 ]
 
 [[package]]
 name = "serde"
 version = "1.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9124df5b40cbd380080b2cc6ab894c040a3070d995f5c9dc77e18c34a8ae37d"
 dependencies = [
- "serde_derive 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
 version = "1.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f2c3ac8e6ca1e9c80b8be1023940162bf81ae3cffbb1809474152f2ce1eb250"
 dependencies = [
- "proc-macro2 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "syn"
 version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb37da98a55b1d08529362d9cbb863be17556873df2585904ab9d2bc951291d0"
 dependencies = [
- "proc-macro2 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
 name = "toml"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"
 dependencies = [
- "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde",
 ]
 
 [[package]]
 name = "unicode-xid"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[metadata]
-"checksum proc-macro2 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)" = "1502d12e458c49a4c9cbff560d0fe0060c252bc29799ed94ca2ed4bb665a0101"
-"checksum quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "54a21852a652ad6f610c9510194f398ff6f8692e334fd1145fed931f7fbe44ea"
-"checksum serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)" = "c9124df5b40cbd380080b2cc6ab894c040a3070d995f5c9dc77e18c34a8ae37d"
-"checksum serde_derive 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)" = "3f2c3ac8e6ca1e9c80b8be1023940162bf81ae3cffbb1809474152f2ce1eb250"
-"checksum syn 1.0.29 (registry+https://github.com/rust-lang/crates.io-index)" = "bb37da98a55b1d08529362d9cbb863be17556873df2585904ab9d2bc951291d0"
-"checksum toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"
-"checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ license = "ISC"
 [dependencies]
 serde = { version = "1.0.111", features = ["derive"] }
 toml = "0.5.6"
+glob = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,6 @@ repository = "https://github.com/dvc94ch/cargo-subcommand"
 license = "ISC"
 
 [dependencies]
+glob = "0.3.0"
 serde = { version = "1.0.111", features = ["derive"] }
 toml = "0.5.6"
-glob = "0.3.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,7 @@
 use std::fmt::{Display, Formatter, Result};
 use std::io::Error as IoError;
 use toml::de::Error as TomlError;
+use glob::{PatternError, GlobError};
 
 #[derive(Debug)]
 pub enum Error {
@@ -8,15 +9,17 @@ pub enum Error {
     ManifestNotFound,
     RustcNotFound,
     Io(IoError),
+    GlobPatternError(&'static str),
 }
 
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter) -> Result {
         let msg = match self {
             Self::InvalidArgs => "Invalid args.",
-            Self::ManifestNotFound => "Didn't find Cargo.toml",
+            Self::ManifestNotFound => "Didn't find Cargo.toml.",
             Self::RustcNotFound => "Didn't find rustc.",
             Self::Io(error) => return error.fmt(f),
+            Self::GlobPatternError(error) => error,
         };
         write!(f, "{}", msg)
     }
@@ -33,5 +36,17 @@ impl From<IoError> for Error {
 impl From<TomlError> for Error {
     fn from(_error: TomlError) -> Self {
         Self::ManifestNotFound
+    }
+}
+
+impl From<PatternError> for Error {
+    fn from(error: PatternError) -> Self {
+        Self::GlobPatternError(error.msg)
+    }
+}
+
+impl From<GlobError> for Error {
+    fn from(error: GlobError) -> Self {
+        Self::Io(error.into_error())
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
+use glob::{GlobError, PatternError};
 use std::fmt::{Display, Formatter, Result};
 use std::io::Error as IoError;
 use toml::de::Error as TomlError;
-use glob::{PatternError, GlobError};
 
 #[derive(Debug)]
 pub enum Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,11 @@
 mod artifact;
-mod profile;
 mod error;
 mod manifest;
+mod profile;
 mod subcommand;
 mod utils;
 
 pub use artifact::{Artifact, CrateType};
-pub use profile::Profile;
 pub use error::Error;
+pub use profile::Profile;
 pub use subcommand::Subcommand;

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -1,10 +1,10 @@
+use crate::artifact::Artifact;
 use crate::error::Error;
 use crate::profile::Profile;
-use crate::artifact::Artifact;
 use crate::utils;
+use std::io::BufRead;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::io::BufRead;
 
 #[derive(Debug)]
 pub struct Subcommand {
@@ -84,14 +84,14 @@ impl Subcommand {
             package.as_ref().map(|s| &**s),
         )?;
         let root_dir = manifest.parent().unwrap();
-        let target_dir = target_dir
-            .unwrap_or_else(|| {
-                utils::find_workspace(&manifest, &package).unwrap()
-                    .unwrap_or_else(|| manifest.clone())
-                    .parent()
-                    .unwrap()
-                    .join("target")
-            });
+        let target_dir = target_dir.unwrap_or_else(|| {
+            utils::find_workspace(&manifest, &package)
+                .unwrap()
+                .unwrap_or_else(|| manifest.clone())
+                .parent()
+                .unwrap()
+                .join("target")
+        });
         if examples {
             for file in utils::list_rust_files(&root_dir.join("examples"))? {
                 artifacts.push(Artifact::Example(file));

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -35,7 +35,8 @@ fn member(manifest: &Path, members: &[String], package: &str) -> Result<Option<P
 
 pub fn find_package(path: &Path, name: Option<&str>) -> Result<(PathBuf, String), Error> {
     let path = std::fs::canonicalize(path)?;
-    for manifest_path in path.ancestors()
+    for manifest_path in path
+        .ancestors()
         .map(|dir| dir.join("Cargo.toml"))
         .filter(|dir| dir.exists())
     {
@@ -60,7 +61,8 @@ pub fn find_package(path: &Path, name: Option<&str>) -> Result<(PathBuf, String)
 
 pub fn find_workspace(manifest: &Path, name: &str) -> Result<Option<PathBuf>, Error> {
     let dir = manifest.parent().unwrap();
-    for manifest_path in dir.ancestors()
+    for manifest_path in dir
+        .ancestors()
         .map(|dir| dir.join("Cargo.toml"))
         .filter(|dir| dir.exists())
     {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -20,12 +20,13 @@ pub fn list_rust_files(dir: &Path) -> Result<Vec<String>, Error> {
 
 fn member(manifest: &Path, members: &[String], package: &str) -> Result<Option<PathBuf>, Error> {
     for member in members {
-        let member = member.split('/').collect::<PathBuf>();
-        let manifest_path = manifest.parent().unwrap().join(member).join("Cargo.toml");
-        let manifest = Manifest::parse_from_toml(&manifest_path)?;
-        if let Some(p) = manifest.package.as_ref() {
-            if p.name == package {
-                return Ok(Some(manifest_path));
+        for member in glob::glob(member)? {
+            let manifest_path = manifest.parent().unwrap().join(member?).join("Cargo.toml");
+            let manifest = Manifest::parse_from_toml(&manifest_path)?;
+            if let Some(p) = manifest.package.as_ref() {
+                if p.name == package {
+                    return Ok(Some(manifest_path));
+                }
             }
         }
     }


### PR DESCRIPTION
Fix issue where e.g. wildcards result in Err that is unwrapped by the calling function, resulting an unnecessary build fail as the target fall through is unused.

This popped up when trying to build Bevy (with winit) for Android. It wasn't clear to me that this is the right place to address the issue, for instance it could instead be handled at the calling function's unwrap. In this case the early return also precludes checking following members, so this felt the the nicer way to cleanup given the crate is using a lot of unwraps and removing one wouldn't have put much a dent in it.