### PR TITLE
utils: Search for workspace members relative to root manifest

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -19,9 +19,10 @@ pub fn list_rust_files(dir: &Path) -> Result<Vec<String>, Error> {
 }
 
 fn member(manifest: &Path, members: &[String], package: &str) -> Result<Option<PathBuf>, Error> {
+    let workspace_dir = manifest.parent().unwrap();
     for member in members {
-        for member in glob::glob(member)? {
-            let manifest_path = manifest.parent().unwrap().join(member?).join("Cargo.toml");
+        for manifest_dir in glob::glob(workspace_dir.join(member).to_str().unwrap())? {
+            let manifest_path = manifest_dir?.join("Cargo.toml");
             let manifest = Manifest::parse_from_toml(&manifest_path)?;
             if let Some(p) = manifest.package.as_ref() {
                 if p.name == package {


### PR DESCRIPTION
Workspace members (globs) should be discovered from the directory containing `Cargo.toml` with these workspaces, not from the directory the user happens to in.

Take for example android-ndk-rs. When cd'd into `ndk-examples` this would find the root manifest file in `../Cargo.toml`, but try to glob in the current directory - `ndk-examples` - where it's obviously not going to find another `ndk-examples` containing `Cargo.toml`. The `Subcommand` constructor hence considers this package as not being in a workspace and emits `target_dir` at `ndk-examples/target`. This fails later in the build when files cannot be found in the toplevel `target/` dir.

Fixes https://github.com/rust-windowing/android-ndk-rs/issues/105
