### PR TITLE
subcommand: Do not canonicalize `target/` path that may not exist

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -35,7 +35,7 @@ fn member(manifest: &Path, members: &[String], package: &str) -> Result<Option<P
 }
 
 pub fn find_package(path: &Path, name: Option<&str>) -> Result<(PathBuf, String), Error> {
-    let path = std::fs::canonicalize(path)?;
+    let path = path.canonicalize()?;
     for manifest_path in path
         .ancestors()
         .map(|dir| dir.join("Cargo.toml"))


### PR DESCRIPTION
Canonicalization requires the path to exist such that the OS can resolve symlinks. The `target/` folder doesn't exist in a clean build environment (ie. after cloning or running `cargo clean`), causing the unwrap to panic.

The same logic is applied to paths coming from `--target-dir` which may or may not be relative. Paths from `find_workspace` (based on those from `find_package`) are already canonicalized, however.

Tested normal `cargo apk` invocation with and without `target/` dir, and `CARGO_TARGET_DIR` with relative and absolute path.

Fixes: bec3883 ("subcommand: Listen to CARGO_(BUILD_)TARGET_DIR over cwd (#4)")
