### PR TITLE
utils: Strip UNC from canonicalized path which is not supported by glob

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,10 +4,17 @@
 name = "cargo-subcommand"
 version = "0.4.9"
 dependencies = [
+ "dunce",
  "glob",
  "serde",
  "toml",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2641c4a7c0c4101df53ea572bffdc561c146f6c2eb09e4df02bc4811e3feeb4"
 
 [[package]]
 name = "glob"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/dvc94ch/cargo-subcommand"
 license = "ISC"
 
 [dependencies]
+dunce = "1"
 glob = "0.3.0"
 serde = { version = "1.0.118", features = ["derive"] }
 toml = "0.5.8"

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -35,7 +35,7 @@ fn member(manifest: &Path, members: &[String], package: &str) -> Result<Option<P
 }
 
 pub fn find_package(path: &Path, name: Option<&str>) -> Result<(PathBuf, String), Error> {
-    let path = path.canonicalize()?;
+    let path = dunce::canonicalize(path)?;
     for manifest_path in path
         .ancestors()
         .map(|dir| dir.join("Cargo.toml"))


### PR DESCRIPTION
We recently taught `fn member()` to look for Cargo.toml files in
workspace members (globs) relative to the workspace root (the directory
containing Cargo.toml with the `[workspace]` listing of these members).
This means the path to the workspace root is now concatenated to the
glob path before searching, which didn't happen before.  That path
happens to be canonicalized just at the top of `fn find_package()`
consequently the whole thing falls apart when Windows UNC paths are used
in places they aren't supported, like `glob`.  No paths are returned,
the package isn't found (`Error::ManifestNotFound` below) and
`cargo-apk` is once again broken on Windows.

We have already been discussing to add `dunce`, now is the right time to
get rid of UNC paths in `cargo-submodule` once and for all.

Fixes: 60fdf8b ("utils: Search for workspace members relative to root manifest (#3)")

CC @dvc94ch @msiglreith