### PR TITLE
Read target-dir from cargo config file

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,40 @@
+use crate::utils;
+use std::path::Path;
+use toml::Value;
+
+/**
+ * Extract the [build.target-dir] string from cargo config file
+ * 
+ * - Receive the workspace root path
+ */
+pub fn get_targer_dir_name(path: &Path) -> String {
+    // Check if the file exists
+    if let Some(config_file_path) = utils::find_cargo_config(&path).unwrap() {
+        // Get file content as string
+        let contents = std::fs::read_to_string(config_file_path).unwrap();
+        // Parse file content to toml::Value
+        let config = contents.parse::<Value>();
+
+        // Check if parsed sucessfully
+        if config.is_ok() {
+            let config = config.ok();
+
+            match config {
+                Some(c) => {
+                    // Check if [build] exists
+                    if let Some(build) = c.get("build") {
+                        // Check if [build] has target-dir
+                        if let Some(target_dir) = build.get("target-dir") {
+                            // Remove trailing "
+                            return target_dir.to_string().replace("\"", "");
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    // Return target as default folder name
+    "target".to_string()
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,40 +1,21 @@
-use crate::utils;
+use crate::error::Error;
+use serde::Deserialize;
 use std::path::Path;
-use toml::Value;
 
-/**
- * Extract the [build.target-dir] string from cargo config file
- * 
- * - Receive the workspace root path
- */
-pub fn get_targer_dir_name(path: &Path) -> String {
-    // Check if the file exists
-    if let Some(config_file_path) = utils::find_cargo_config(&path).unwrap() {
-        // Get file content as string
-        let contents = std::fs::read_to_string(config_file_path).unwrap();
-        // Parse file content to toml::Value
-        let config = contents.parse::<Value>();
+#[derive(Debug, Deserialize)]
+pub struct Config {
+    pub build: Option<Build>,
+}
 
-        // Check if parsed sucessfully
-        if config.is_ok() {
-            let config = config.ok();
-
-            match config {
-                Some(c) => {
-                    // Check if [build] exists
-                    if let Some(build) = c.get("build") {
-                        // Check if [build] has target-dir
-                        if let Some(target_dir) = build.get("target-dir") {
-                            // Remove trailing "
-                            return target_dir.to_string().replace("\"", "");
-                        }
-                    }
-                }
-                _ => {}
-            }
-        }
+impl Config {
+    pub fn parse_from_toml(path: &Path) -> Result<Self, Error> {
+        let contents = std::fs::read_to_string(path)?;
+        Ok(toml::from_str(&contents)?)
     }
+}
 
-    // Return target as default folder name
-    "target".to_string()
+#[derive(Debug, Deserialize)]
+pub struct Build {
+    #[serde(rename = "target-dir")]
+    pub target_dir: Option<String>,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,6 +6,7 @@ use toml::de::Error as TomlError;
 #[derive(Debug)]
 pub enum Error {
     InvalidArgs,
+    InvalidConfig,
     ManifestNotFound,
     RustcNotFound,
     Io(IoError),
@@ -16,6 +17,7 @@ impl Display for Error {
     fn fmt(&self, f: &mut Formatter) -> Result {
         let msg = match self {
             Self::InvalidArgs => "Invalid args.",
+            Self::InvalidConfig => "Invalid config.",
             Self::ManifestNotFound => "Didn't find Cargo.toml.",
             Self::RustcNotFound => "Didn't find rustc.",
             Self::Io(error) => return error.fmt(f),

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,7 +6,6 @@ use toml::de::Error as TomlError;
 #[derive(Debug)]
 pub enum Error {
     InvalidArgs,
-    InvalidConfig,
     ManifestNotFound,
     RustcNotFound,
     Io(IoError),
@@ -17,7 +16,6 @@ impl Display for Error {
     fn fmt(&self, f: &mut Formatter) -> Result {
         let msg = match self {
             Self::InvalidArgs => "Invalid args.",
-            Self::InvalidConfig => "Invalid .cargo/config.toml",
             Self::ManifestNotFound => "Didn't find Cargo.toml.",
             Self::RustcNotFound => "Didn't find rustc.",
             Self::Io(error) => return error.fmt(f),

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,7 +17,7 @@ impl Display for Error {
     fn fmt(&self, f: &mut Formatter) -> Result {
         let msg = match self {
             Self::InvalidArgs => "Invalid args.",
-            Self::InvalidConfig => "Invalid config.",
+            Self::InvalidConfig => "Invalid .cargo/config.toml",
             Self::ManifestNotFound => "Didn't find Cargo.toml.",
             Self::RustcNotFound => "Didn't find rustc.",
             Self::Io(error) => return error.fmt(f),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 mod artifact;
+mod config;
 mod error;
 mod manifest;
 mod profile;

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -1,4 +1,5 @@
 use crate::artifact::Artifact;
+use crate::config;
 use crate::error::Error;
 use crate::profile::Profile;
 use crate::utils;
@@ -105,7 +106,8 @@ impl Subcommand {
                 .unwrap_or_else(|| manifest.clone())
                 .parent()
                 .unwrap()
-                .join("target")
+                // Get target dir name from config
+                .join(config::get_targer_dir_name(&root_dir))
         });
         if examples {
             for file in utils::list_rust_files(&root_dir.join("examples"))? {

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -105,7 +105,6 @@ impl Subcommand {
                 .unwrap_or_else(|| manifest.clone())
                 .parent()
                 .unwrap()
-                // Get target dir name from config
                 .join(utils::get_target_dir_name(&root_dir).unwrap())
         });
         if examples {

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -1,5 +1,4 @@
 use crate::artifact::Artifact;
-use crate::config;
 use crate::error::Error;
 use crate::profile::Profile;
 use crate::utils;
@@ -107,7 +106,7 @@ impl Subcommand {
                 .parent()
                 .unwrap()
                 // Get target dir name from config
-                .join(config::get_targer_dir_name(&root_dir))
+                .join(utils::get_target_dir_name(&root_dir).unwrap())
         });
         if examples {
             for file in utils::list_rust_files(&root_dir.join("examples"))? {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,4 @@
+use crate::config::Config;
 use crate::error::Error;
 use crate::manifest::Manifest;
 use std::ffi::OsStr;
@@ -79,7 +80,7 @@ pub fn find_workspace(manifest: &Path, name: &str) -> Result<Option<PathBuf>, Er
 
 /**
  * Search for .cargo/config.toml file
- * 
+ *
  * - Receive the workspace root path
  */
 pub fn find_cargo_config(path: &Path) -> Result<Option<PathBuf>, Error> {
@@ -92,4 +93,18 @@ pub fn find_cargo_config(path: &Path) -> Result<Option<PathBuf>, Error> {
         return Ok(Some(config_path));
     }
     Ok(None)
+}
+
+pub fn get_target_dir_name(path: &Path) -> Result<String, Error> {
+    if let Some(config_path) = find_cargo_config(&path).unwrap() {
+        let config = Config::parse_from_toml(&config_path)?;
+        if let Some(build) = config.build.as_ref() {
+            if let Some(target_dir) = &build.target_dir {
+                return Ok(target_dir.clone());
+            }
+        }
+    } else {
+        return Ok("target".to_string());
+    }
+    Err(Error::InvalidConfig)
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -95,7 +95,6 @@ pub fn get_target_dir_name(path: &Path) -> Result<String, Error> {
                 return Ok(target_dir.clone());
             }
         }
-        Err(Error::InvalidConfig)
     } else {
         Ok("target".to_string())
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -95,7 +95,6 @@ pub fn get_target_dir_name(path: &Path) -> Result<String, Error> {
                 return Ok(target_dir.clone());
             }
         }
-    } else {
-        Ok("target".to_string())
     }
+    Ok("target".to_string())
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -76,3 +76,26 @@ pub fn find_workspace(manifest: &Path, name: &str) -> Result<Option<PathBuf>, Er
     }
     Ok(None)
 }
+
+/**
+ * Search for .cargo/config.toml file
+ * 
+ * - Receive the workspace root path
+ */
+pub fn find_cargo_config(path: &Path) -> Result<Option<PathBuf>, Error> {
+    let path = dunce::canonicalize(path)?;
+    for config_folder_path in path
+        .ancestors()
+        .map(|dir| dir.join(".cargo"))
+        .filter(|dir| dir.exists())
+    {
+        for config_file_path in config_folder_path
+            .ancestors()
+            .map(|dir| dir.join("config.toml"))
+            .filter(|dir| dir.exists())
+        {
+            return Ok(Some(config_file_path));
+        }
+    }
+    Ok(None)
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -84,18 +84,12 @@ pub fn find_workspace(manifest: &Path, name: &str) -> Result<Option<PathBuf>, Er
  */
 pub fn find_cargo_config(path: &Path) -> Result<Option<PathBuf>, Error> {
     let path = dunce::canonicalize(path)?;
-    for config_folder_path in path
+    for config_path in path
         .ancestors()
-        .map(|dir| dir.join(".cargo"))
-        .filter(|dir| dir.exists())
+        .map(|dir| dir.join(".cargo/config.toml"))
+        .filter(|dir| dir.is_file())
     {
-        for config_file_path in config_folder_path
-            .ancestors()
-            .map(|dir| dir.join("config.toml"))
-            .filter(|dir| dir.exists())
-        {
-            return Ok(Some(config_file_path));
-        }
+        return Ok(Some(config_path));
     }
     Ok(None)
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -78,11 +78,7 @@ pub fn find_workspace(manifest: &Path, name: &str) -> Result<Option<PathBuf>, Er
     Ok(None)
 }
 
-/**
- * Search for .cargo/config.toml file
- *
- * - Receive the workspace root path
- */
+/// Search for .cargo/config.toml file relative to the workspace root path.
 pub fn find_cargo_config(path: &Path) -> Result<Option<PathBuf>, Error> {
     let path = dunce::canonicalize(path)?;
     path

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -85,26 +85,22 @@ pub fn find_workspace(manifest: &Path, name: &str) -> Result<Option<PathBuf>, Er
  */
 pub fn find_cargo_config(path: &Path) -> Result<Option<PathBuf>, Error> {
     let path = dunce::canonicalize(path)?;
-    for config_path in path
+    path
         .ancestors()
         .map(|dir| dir.join(".cargo/config.toml"))
-        .filter(|dir| dir.is_file())
-    {
-        return Ok(Some(config_path));
-    }
-    Ok(None)
+        .find(|dir| dir.is_file())
 }
 
 pub fn get_target_dir_name(path: &Path) -> Result<String, Error> {
-    if let Some(config_path) = find_cargo_config(&path).unwrap() {
+    if let Some(config_path) = find_cargo_config(&path)? {
         let config = Config::parse_from_toml(&config_path)?;
         if let Some(build) = config.build.as_ref() {
             if let Some(target_dir) = &build.target_dir {
                 return Ok(target_dir.clone());
             }
         }
+        Err(Error::InvalidConfig)
     } else {
-        return Ok("target".to_string());
+        Ok("target".to_string())
     }
-    Err(Error::InvalidConfig)
 }


### PR DESCRIPTION
Read config from .cargo/config.toml

Fix an error where the target directory was hard coded, causing problems when a different target directory was used.

https://github.com/rust-windowing/android-ndk-rs/issues/102