### PR TITLE
error: Include file paths as error context; distinguish toml parsing errors from "manifest not found"

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -10,7 +10,7 @@ pub struct Config {
 impl Config {
     pub fn parse_from_toml(path: &Path) -> Result<Self, Error> {
         let contents = std::fs::read_to_string(path)?;
-        Ok(toml::from_str(&contents)?)
+        toml::from_str(&contents).map_err(|e| Error::Toml(path.to_owned(), e))
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,7 +9,7 @@ pub struct Config {
 
 impl Config {
     pub fn parse_from_toml(path: &Path) -> Result<Self, Error> {
-        let contents = std::fs::read_to_string(path)?;
+        let contents = std::fs::read_to_string(path).map_err(|e| Error::Io(path.to_owned(), e))?;
         toml::from_str(&contents).map_err(|e| Error::Toml(path.to_owned(), e))
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,8 +9,9 @@ pub enum Error {
     InvalidArgs,
     ManifestNotFound,
     RustcNotFound,
-    Io(IoError),
     GlobPatternError(&'static str),
+    Glob(GlobError),
+    Io(PathBuf, IoError),
     Toml(PathBuf, TomlError),
 }
 
@@ -20,8 +21,9 @@ impl Display for Error {
             Self::InvalidArgs => "Invalid args.",
             Self::ManifestNotFound => "Didn't find Cargo.toml.",
             Self::RustcNotFound => "Didn't find rustc.",
-            Self::Io(error) => return error.fmt(f),
             Self::GlobPatternError(error) => error,
+            Self::Glob(error) => return error.fmt(f),
+            Self::Io(path, error) => return write!(f, "{}: {}", path.display(), error),
             Self::Toml(file, error) => return write!(f, "{}: {}", file.display(), error),
         };
         write!(f, "{}", msg)
@@ -29,12 +31,6 @@ impl Display for Error {
 }
 
 impl std::error::Error for Error {}
-
-impl From<IoError> for Error {
-    fn from(error: IoError) -> Self {
-        Self::Io(error)
-    }
-}
 
 impl From<PatternError> for Error {
     fn from(error: PatternError) -> Self {
@@ -44,6 +40,6 @@ impl From<PatternError> for Error {
 
 impl From<GlobError> for Error {
     fn from(error: GlobError) -> Self {
-        Self::Io(error.into_error())
+        Self::Glob(error)
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,7 @@
 use glob::{GlobError, PatternError};
 use std::fmt::{Display, Formatter, Result};
 use std::io::Error as IoError;
+use std::path::PathBuf;
 use toml::de::Error as TomlError;
 
 #[derive(Debug)]
@@ -10,7 +11,7 @@ pub enum Error {
     RustcNotFound,
     Io(IoError),
     GlobPatternError(&'static str),
-    Toml(TomlError),
+    Toml(PathBuf, TomlError),
 }
 
 impl Display for Error {
@@ -21,7 +22,7 @@ impl Display for Error {
             Self::RustcNotFound => "Didn't find rustc.",
             Self::Io(error) => return error.fmt(f),
             Self::GlobPatternError(error) => error,
-            Self::Toml(error) => return error.fmt(f),
+            Self::Toml(file, error) => return write!(f, "{}: {}", file.display(), error),
         };
         write!(f, "{}", msg)
     }
@@ -32,12 +33,6 @@ impl std::error::Error for Error {}
 impl From<IoError> for Error {
     fn from(error: IoError) -> Self {
         Self::Io(error)
-    }
-}
-
-impl From<TomlError> for Error {
-    fn from(error: TomlError) -> Self {
-        Self::Toml(error)
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,6 +10,7 @@ pub enum Error {
     RustcNotFound,
     Io(IoError),
     GlobPatternError(&'static str),
+    Toml(TomlError),
 }
 
 impl Display for Error {
@@ -20,6 +21,7 @@ impl Display for Error {
             Self::RustcNotFound => "Didn't find rustc.",
             Self::Io(error) => return error.fmt(f),
             Self::GlobPatternError(error) => error,
+            Self::Toml(error) => return error.fmt(f),
         };
         write!(f, "{}", msg)
     }
@@ -34,8 +36,8 @@ impl From<IoError> for Error {
 }
 
 impl From<TomlError> for Error {
-    fn from(_error: TomlError) -> Self {
-        Self::ManifestNotFound
+    fn from(error: TomlError) -> Self {
+        Self::Toml(error)
     }
 }
 

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -11,7 +11,7 @@ pub struct Manifest {
 impl Manifest {
     pub fn parse_from_toml(path: &Path) -> Result<Self, Error> {
         let contents = std::fs::read_to_string(path)?;
-        Ok(toml::from_str(&contents)?)
+        toml::from_str(&contents).map_err(|e| Error::Toml(path.to_owned(), e))
     }
 }
 

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -10,7 +10,7 @@ pub struct Manifest {
 
 impl Manifest {
     pub fn parse_from_toml(path: &Path) -> Result<Self, Error> {
-        let contents = std::fs::read_to_string(path)?;
+        let contents = std::fs::read_to_string(path).map_err(|e| Error::Io(path.to_owned(), e))?;
         toml::from_str(&contents).map_err(|e| Error::Toml(path.to_owned(), e))
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,9 +7,9 @@ use std::path::{Path, PathBuf};
 pub fn list_rust_files(dir: &Path) -> Result<Vec<String>, Error> {
     let mut files = Vec::new();
     if dir.exists() && dir.is_dir() {
-        let entries = std::fs::read_dir(dir)?;
+        let entries = std::fs::read_dir(dir).map_err(|e| Error::Io(dir.to_owned(), e))?;
         for entry in entries {
-            let path = entry?.path();
+            let path = entry.map_err(|e| Error::Io(dir.to_owned(), e))?.path();
             if path.is_file() && path.extension() == Some(OsStr::new("rs")) {
                 let name = path.file_stem().unwrap().to_str().unwrap();
                 files.push(name.to_string());
@@ -36,7 +36,7 @@ fn member(manifest: &Path, members: &[String], package: &str) -> Result<Option<P
 }
 
 pub fn find_package(path: &Path, name: Option<&str>) -> Result<(PathBuf, String), Error> {
-    let path = dunce::canonicalize(path)?;
+    let path = dunce::canonicalize(path).map_err(|e| Error::Io(path.to_owned(), e))?;
     for manifest_path in path
         .ancestors()
         .map(|dir| dir.join("Cargo.toml"))
@@ -80,7 +80,7 @@ pub fn find_workspace(manifest: &Path, name: &str) -> Result<Option<PathBuf>, Er
 
 /// Search for .cargo/config.toml file relative to the workspace root path.
 pub fn find_cargo_config(path: &Path) -> Result<Option<PathBuf>, Error> {
-    let path = dunce::canonicalize(path)?;
+    let path = dunce::canonicalize(path).map_err(|e| Error::Io(path.to_owned(), e))?;
     Ok(path
         .ancestors()
         .map(|dir| dir.join(".cargo/config.toml"))


### PR DESCRIPTION
While implementing #12 an invalid `.cargo/config.toml` turned into an undescriptive and incorrect `ManifestNotFound` here.  Forwarding the parsing error gives the user a much more descriptive error message that'll help understand what to fix.
