### PR TITLE
Propagate `.cargo/config.toml` `[env]` settings to the process environment

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -17,7 +17,7 @@ pub enum Error {
 
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter) -> Result {
-        let msg = match self {
+        f.write_str(match self {
             Self::InvalidArgs => "Invalid args.",
             Self::ManifestNotFound => "Didn't find Cargo.toml.",
             Self::RustcNotFound => "Didn't find rustc.",
@@ -25,8 +25,7 @@ impl Display for Error {
             Self::Glob(error) => return error.fmt(f),
             Self::Io(path, error) => return write!(f, "{}: {}", path.display(), error),
             Self::Toml(file, error) => return write!(f, "{}: {}", file.display(), error),
-        };
-        write!(f, "{}", msg)
+        })
     }
 }
 

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -104,7 +104,12 @@ impl Subcommand {
                 }
             });
 
+        // TODO: Find, parse, and merge _all_ config files following the hierarchical structure:
+        // https://doc.rust-lang.org/cargo/reference/config.html#hierarchical-structure
         let config = LocalizedConfig::find_cargo_config_for_workspace(&root_dir)?;
+        if let Some(config) = &config {
+            config.set_env_vars().unwrap();
+        }
 
         let target_dir = target_dir.unwrap_or_else(|| {
             utils::find_workspace(&manifest, &package)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -80,7 +80,7 @@ pub fn find_workspace(manifest: &Path, name: &str) -> Result<Option<PathBuf>, Er
 
 /// Returns the [`target-dir`] configured in `.cargo/config.toml` or `"target"` if not set.
 ///
-/// [`target-dir`](https://doc.rust-lang.org/cargo/reference/config.html#buildtarget-dir)
+/// [`target-dir`]: https://doc.rust-lang.org/cargo/reference/config.html#buildtarget-dir
 pub fn get_target_dir_name(config: Option<&Config>) -> Result<String, Error> {
     if let Some(config) = config {
         if let Some(build) = config.build.as_ref() {


### PR DESCRIPTION
Leaving the caller to read and merge config environment values with the process environment is not only cumbersome as seen in [rust-windowing/android-ndk-rs#233], but these values need to be propagated into the process environment anyway to be usable by any subprocess spawned by the caller (ie. `cargo-apk` spawning `cargo rustc`, which can internally spawn a bunch of compilers and linkers too).

Instead, do this automatically when the caller invokes `Subcommand::new` while still leaving the door open for crates to read the environment from the public `subcommand.manifest.env` member.

[rust-windowing/android-ndk-rs#233]: https://github.com/rust-windowing/android-ndk-rs/pull/233
