### PR TITLE
subcommand: Parse and propagate `[env]` vars at the earliest possible moment

### DIFF
--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -43,6 +43,13 @@ impl Subcommand {
         )?;
         let root_dir = manifest_path.parent().unwrap();
 
+        // TODO: Find, parse, and merge _all_ config files following the hierarchical structure:
+        // https://doc.rust-lang.org/cargo/reference/config.html#hierarchical-structure
+        let config = LocalizedConfig::find_cargo_config_for_workspace(&root_dir)?;
+        if let Some(config) = &config {
+            config.set_env_vars().unwrap();
+        }
+
         let target_dir = args
             .target_dir
             .clone()
@@ -58,13 +65,6 @@ impl Subcommand {
                     target_dir
                 }
             });
-
-        // TODO: Find, parse, and merge _all_ config files following the hierarchical structure:
-        // https://doc.rust-lang.org/cargo/reference/config.html#hierarchical-structure
-        let config = LocalizedConfig::find_cargo_config_for_workspace(&root_dir)?;
-        if let Some(config) = &config {
-            config.set_env_vars().unwrap();
-        }
 
         let target_dir = target_dir.unwrap_or_else(|| {
             utils::find_workspace(&manifest_path, &package)


### PR DESCRIPTION
Strangely enough I added this call at a random place in `Subcommand::new()`, instead of considering that it was both:
1. Breaking the logic for deducing `target_dir` in two separated blocks;
2. Preventing the first block - which reads environment variables! - from seeing what was configured in `.cargo/config.toml` through `[env]`.

Fix this by moving the call straight after identifying the root directory for the selected package.
