### PR TITLE
Fix `--manifest-path` to point to `Cargo.toml` instead of a directory

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -9,6 +9,7 @@ pub enum Error {
     InvalidArgs,
     ManifestNotFound,
     RustcNotFound,
+    ManifestPathNotFound,
     GlobPatternError(&'static str),
     Glob(GlobError),
     Io(PathBuf, IoError),
@@ -20,6 +21,7 @@ impl Display for Error {
         f.write_str(match self {
             Self::InvalidArgs => "Invalid args.",
             Self::ManifestNotFound => "Didn't find Cargo.toml.",
+            Self::ManifestPathNotFound => "The manifest-path must be a path to a Cargo.toml file",
             Self::RustcNotFound => "Didn't find rustc.",
             Self::GlobPatternError(error) => error,
             Self::Glob(error) => return error.fmt(f),


### PR DESCRIPTION
Currently `cargo-subcommand` expects this argument to be a path to the directory containing project(s), whereas it should actually point to a file specifically named `Cargo.toml`.

Note that this path doesn't appear to be very strict in `cargo`: even if pointing to a manifest file within a workspace, packages in the surrounding workspace are still built, and are reachable through `-p`.

However, there's a strict requirement on the specified manifest to be part of the workspace, which is not enforced in `cargo-subcommand` yet.
