### PR TITLE
manifest: Be more specific about not supporting multiple packages yet

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -17,6 +17,8 @@ pub enum EnvError {
     Var(VarError),
 }
 
+pub type Result<T, E = EnvError> = std::result::Result<T, E>;
+
 impl From<VarError> for EnvError {
     fn from(var: VarError) -> Self {
         Self::Var(var)
@@ -33,8 +35,6 @@ impl Display for EnvError {
 }
 
 impl std::error::Error for EnvError {}
-
-type Result<T, E = EnvError> = std::result::Result<T, E>;
 
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "kebab-case")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,5 @@
 use glob::{GlobError, PatternError};
-use std::fmt::{Display, Formatter, Result};
+use std::fmt::{Display, Formatter, Result as FmtResult};
 use std::io::Error as IoError;
 use std::path::PathBuf;
 use toml::de::Error as TomlError;
@@ -10,18 +10,24 @@ pub enum Error {
     ManifestNotFound,
     RustcNotFound,
     ManifestPathNotFound,
+    MultiplePackagesNotSupported,
     GlobPatternError(&'static str),
     Glob(GlobError),
     Io(PathBuf, IoError),
     Toml(PathBuf, TomlError),
 }
 
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
 impl Display for Error {
-    fn fmt(&self, f: &mut Formatter) -> Result {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
         f.write_str(match self {
             Self::InvalidArgs => "Invalid args.",
             Self::ManifestNotFound => "Didn't find Cargo.toml.",
             Self::ManifestPathNotFound => "The manifest-path must be a path to a Cargo.toml file",
+            Self::MultiplePackagesNotSupported => {
+                "Multiple packages are not yet supported (ie. in a `[workspace]`). Use `-p` to select a specific package."
+            }
             Self::RustcNotFound => "Didn't find rustc.",
             Self::GlobPatternError(error) => error,
             Self::Glob(error) => return error.fmt(f),

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,4 +1,4 @@
-use crate::error::Error;
+use crate::error::{Error, Result};
 use serde::Deserialize;
 use std::path::Path;
 
@@ -9,7 +9,7 @@ pub struct Manifest {
 }
 
 impl Manifest {
-    pub fn parse_from_toml(path: &Path) -> Result<Self, Error> {
+    pub fn parse_from_toml(path: &Path) -> Result<Self> {
         let contents = std::fs::read_to_string(path).map_err(|e| Error::Io(path.to_owned(), e))?;
         toml::from_str(&contents).map_err(|e| Error::Toml(path.to_owned(), e))
     }

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -1,6 +1,6 @@
 use crate::args::Args;
 use crate::artifact::{Artifact, CrateType};
-use crate::error::Error;
+use crate::error::{Error, Result};
 use crate::profile::Profile;
 use crate::{utils, LocalizedConfig};
 use std::ffi::OsStr;
@@ -21,7 +21,7 @@ pub struct Subcommand {
 }
 
 impl Subcommand {
-    pub fn new(args: Args) -> Result<Self, Error> {
+    pub fn new(args: Args) -> Result<Self> {
         // TODO: support multiple packages properly
         assert!(
             args.package.len() < 2,


### PR DESCRIPTION
When running `cargo-subcommand` without `-p` package selection against a workspace currently only the first found package is returned.  This should be implemented over time to return all packages (and artifacts adhering to target selection), but return a more specific error for the time being instead of making it seem like there's only one package.
