### PR TITLE
Do not call rustc for platform detection; use `current_platform` instead

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,9 @@ default = ["clap"]
 
 [dependencies]
 clap = { version = "3.1.6", optional = true, features = ["derive"] }
+current_platform = "0.2.0"
 dunce = "1.0.1"
 glob = "0.3.0"
 serde = { version = "1.0.123", features = ["derive"] }
 toml = "0.5.8"
-current_platform = "0.2.0"
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ dunce = "1.0.1"
 glob = "0.3.0"
 serde = { version = "1.0.123", features = ["derive"] }
 toml = "0.5.8"
+current_platform = "0.2.0"

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -4,9 +4,7 @@ use crate::error::{Error, Result};
 use crate::profile::Profile;
 use crate::{utils, LocalizedConfig};
 use std::ffi::OsStr;
-use std::io::BufRead;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 #[derive(Debug)]
 pub struct Subcommand {

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -108,16 +108,7 @@ impl Subcommand {
         if artifacts.is_empty() {
             artifacts.push(Artifact::Root(package.clone()));
         }
-        let host_triple = Command::new("rustc")
-            .arg("-vV")
-            .output()
-            .map_err(|_| Error::RustcNotFound)?
-            .stdout
-            .lines()
-            .map(|l| l.unwrap())
-            .find(|l| l.starts_with("host: "))
-            .map(|l| l[6..].to_string())
-            .ok_or(Error::RustcNotFound)?;
+        let host_triple = current_platform::CURRENT_PLATFORM.to_owned();
         let profile = args.profile();
         Ok(Self {
             args,


### PR DESCRIPTION
Use the `current_platform` crate for zero-cost platform detection. Shaves off 90ms off subcommand startup on my machine (invoking rustc is slow when it's managed by rustup).

The `Error::RustcNotFound` variant is now never constructed, but I didn't remove it because that would be a semver-breaking change. Likewise with the superfluous `.to_owned()` - not changed to avoid an API break.

Fixes #19