### PR TITLE
Linearize workspace detection

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -7,12 +7,14 @@ use toml::de::Error as TomlError;
 #[derive(Debug)]
 pub enum Error {
     InvalidArgs,
+    ManifestNotAWorkspace,
     ManifestNotFound,
     RustcNotFound,
     ManifestPathNotFound,
     MultiplePackagesNotSupported,
     GlobPatternError(&'static str),
     Glob(GlobError),
+    UnexpectedWorkspace(PathBuf),
     Io(PathBuf, IoError),
     Toml(PathBuf, TomlError),
 }
@@ -23,6 +25,7 @@ impl Display for Error {
     fn fmt(&self, f: &mut Formatter) -> FmtResult {
         f.write_str(match self {
             Self::InvalidArgs => "Invalid args.",
+            Self::ManifestNotAWorkspace => "The provided Cargo.toml does not contain a `[workspace]`",
             Self::ManifestNotFound => "Didn't find Cargo.toml.",
             Self::ManifestPathNotFound => "The manifest-path must be a path to a Cargo.toml file",
             Self::MultiplePackagesNotSupported => {
@@ -31,6 +34,7 @@ impl Display for Error {
             Self::RustcNotFound => "Didn't find rustc.",
             Self::GlobPatternError(error) => error,
             Self::Glob(error) => return error.fmt(f),
+            Self::UnexpectedWorkspace(path) => return write!(f, "Did not expect a `[workspace]` at {}", path.display()),
             Self::Io(path, error) => return write!(f, "{}: {}", path.display(), error),
             Self::Toml(file, error) => return write!(f, "{}: {}", file.display(), error),
         })


### PR DESCRIPTION
When `cargo` scans for a workspace it simply walks up the directories until finding the first `Cargo.toml` with a `[workspace]` declaration.  All crates are detected relative to this, and no special skipping behaviour (walking further up the directories) occurs when a package was not found (was previously happening in `find_package()+member()`).

Simplify the original code somewhat by making this feat more obvious, rejecting more invalid configurations.
