### PR TITLE
Provide workspace manifest path in `Subcommand`

### DIFF
--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -2,7 +2,7 @@ use crate::error::{Error, Result};
 use serde::Deserialize;
 use std::path::Path;
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct Manifest {
     pub workspace: Option<Workspace>,
     pub package: Option<Package>,
@@ -15,12 +15,12 @@ impl Manifest {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct Workspace {
     pub members: Vec<String>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct Package {
     pub name: String,
 }


### PR DESCRIPTION
Depends on #23

Especially with the new `[workspace.package]` values, `cargo-apk` would like to know the path of the workspace that was found for the requested package, so that `cargo-apk` can scan it for values to inherit.
